### PR TITLE
Fix SVG rendering with file fonts being embedded 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .pytest_cache
 dist
 .idea
+.mypy_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+- Fixed SVG rendering with custom font files being embedded. It was not working because a wrong SVG tag was being used.
+
 ### Added
 
 - Added comprehensive type annotations and mypy static type checking integration

--- a/src/pictex/renderer/vector_image_processor.py
+++ b/src/pictex/renderer/vector_image_processor.py
@@ -68,9 +68,9 @@ class VectorImageProcessor:
         css = self._get_css_code_for_typefaces(typefaces, embed_fonts)
         defs = f"""
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         {css}
-    </builders>
+    </style>
 </defs>
             """
 

--- a/tests/test_background/test_background_image_with_contain_mode_vector_.svg
+++ b/tests/test_background/test_background_image_with_contain_mode_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ns1="http://www.w3.org/1999/xlink" width="400" height="400">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="400" height="400" />

--- a/tests/test_background/test_background_image_with_tile_mode_vector_.svg
+++ b/tests/test_background/test_background_image_with_tile_mode_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ns1="http://www.w3.org/1999/xlink" width="500" height="500">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="500" height="500" />

--- a/tests/test_background/test_background_without_padding_vector_.svg
+++ b/tests/test_background/test_background_without_padding_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="323" height="119">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Oswald';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Oswald-VariableFont_wght.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="323" height="119" />

--- a/tests/test_background/test_render_with_gradient_background_vector_.svg
+++ b/tests/test_background/test_render_with_gradient_background_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="472" height="179">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Oswald';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Oswald-VariableFont_wght.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="472" height="179" />

--- a/tests/test_background/test_render_with_solid_background_vector_.svg
+++ b/tests/test_background/test_render_with_solid_background_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="623" height="179">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Oswald';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Oswald-VariableFont_wght.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="623" height="179" />

--- a/tests/test_border/test_border_style_dashed_vector_.svg
+++ b/tests/test_border/test_border_style_dashed_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="300" height="150" />

--- a/tests/test_border/test_border_style_dotted_vector_.svg
+++ b/tests/test_border/test_border_style_dotted_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="300" height="150" />

--- a/tests/test_border/test_border_with_gradient_color_vector_.svg
+++ b/tests/test_border/test_border_with_gradient_color_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="400" height="200" />

--- a/tests/test_decorations/test_render_with_gradient_decoration_vector_.svg
+++ b/tests/test_decorations/test_render_with_gradient_decoration_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="451" height="96">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="451" height="96" />

--- a/tests/test_decorations/test_render_with_multiple_decorations_vector_.svg
+++ b/tests/test_decorations/test_render_with_multiple_decorations_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="556" height="96">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="556" height="96" />

--- a/tests/test_decorations/test_render_with_strikethrough_custom_color_vector_.svg
+++ b/tests/test_decorations/test_render_with_strikethrough_custom_color_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="463" height="96">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="463" height="96" />

--- a/tests/test_decorations/test_render_with_underline_vector_.svg
+++ b/tests/test_decorations/test_render_with_underline_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="372" height="96">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="372" height="96" />

--- a/tests/test_fonts/test_render_basic_text_and_alignment_vector_Basic_Text_left_.svg
+++ b/tests/test_fonts/test_render_basic_text_and_alignment_vector_Basic_Text_left_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="234" height="58">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="234" height="58" />

--- a/tests/test_fonts/test_render_basic_text_and_alignment_vector_Centered_nMulti_line_center_.svg
+++ b/tests/test_fonts/test_render_basic_text_and_alignment_vector_Centered_nMulti_line_center_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="207" height="108">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="207" height="108" />

--- a/tests/test_fonts/test_render_basic_text_and_alignment_vector_Right_Aligned_nLonger_First_Line_right_.svg
+++ b/tests/test_fonts/test_render_basic_text_and_alignment_vector_Right_Aligned_nLonger_First_Line_right_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="378" height="108">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="378" height="108" />

--- a/tests/test_fonts/test_render_with_custom_static_font_vector_.svg
+++ b/tests/test_fonts/test_render_with_custom_static_font_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="555" height="84">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="555" height="84" />

--- a/tests/test_fonts/test_render_with_default_font_vector_.svg
+++ b/tests/test_fonts/test_render_with_default_font_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="416" height="82">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="416" height="82" />

--- a/tests/test_fonts/test_render_with_font_fallback_for_emoji_vector_.svg
+++ b/tests/test_fonts/test_render_with_font_fallback_for_emoji_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="209" height="84">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="209" height="84" />

--- a/tests/test_fonts/test_render_with_invalid_fonts_vector_.svg
+++ b/tests/test_fonts/test_render_with_invalid_fonts_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="596" height="82">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="596" height="82" />

--- a/tests/test_fonts/test_render_with_system_font_fallback_vector_.svg
+++ b/tests/test_fonts/test_render_with_system_font_fallback_vector_.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="869" height="84">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
@@ -12,7 +12,7 @@
     src: url('/home/runner/work/pictex/pictex/tests/assets/NotoSansJP-Regular.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="869" height="84" />

--- a/tests/test_fonts/test_render_with_variable_font_weight_vector_900_Black_.svg
+++ b/tests/test_fonts/test_render_with_variable_font_weight_vector_900_Black_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="395" height="104">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Oswald';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Oswald-VariableFont_wght.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="395" height="104" />

--- a/tests/test_fonts/test_render_with_variable_font_weight_vector_FontWeight_BOLD_Bold_.svg
+++ b/tests/test_fonts/test_render_with_variable_font_weight_vector_FontWeight_BOLD_Bold_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="363" height="104">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Oswald';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Oswald-VariableFont_wght.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="363" height="104" />

--- a/tests/test_fonts/test_render_with_variable_font_weight_vector_FontWeight_LIGHT_Light_.svg
+++ b/tests/test_fonts/test_render_with_variable_font_weight_vector_FontWeight_LIGHT_Light_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="319" height="104">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Oswald';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Oswald-VariableFont_wght.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="319" height="104" />

--- a/tests/test_fonts/test_render_with_variable_font_weight_vector_FontWeight_NORMAL_Regular_.svg
+++ b/tests/test_fonts/test_render_with_variable_font_weight_vector_FontWeight_NORMAL_Regular_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="404" height="104">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Oswald';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Oswald-VariableFont_wght.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="404" height="104" />

--- a/tests/test_gradients/test_gradient_direction_vertical_vector_.svg
+++ b/tests/test_gradients/test_gradient_direction_vertical_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="587" height="138">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="587" height="138" />

--- a/tests/test_gradients/test_gradient_on_text_fill_vector_.svg
+++ b/tests/test_gradients/test_gradient_on_text_fill_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="620" height="138">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="620" height="138" />

--- a/tests/test_gradients/test_gradient_with_custom_stops_vector_.svg
+++ b/tests/test_gradients/test_gradient_with_custom_stops_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="446" height="178">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="446" height="178" />

--- a/tests/test_integration/test_kitchen_sink_all_features_combined_vector_.svg
+++ b/tests/test_integration/test_kitchen_sink_all_features_combined_vector_.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ns1="http://www.w3.org/1999/xlink" width="565" height="536">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Oswald';
@@ -12,7 +12,7 @@
     src: url('/home/runner/work/pictex/pictex/tests/assets/Oswald-VariableFont_wght.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="565" height="536" />

--- a/tests/test_layout/test_column_default_layout_vector_.svg
+++ b/tests/test_layout/test_column_default_layout_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="237">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="237" />

--- a/tests/test_layout/test_column_horizontal_alignment_vector_center_.svg
+++ b/tests/test_layout/test_column_horizontal_alignment_vector_center_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="237">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="237" />

--- a/tests/test_layout/test_column_horizontal_alignment_vector_left_.svg
+++ b/tests/test_layout/test_column_horizontal_alignment_vector_left_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="237">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="237" />

--- a/tests/test_layout/test_column_horizontal_alignment_vector_right_.svg
+++ b/tests/test_layout/test_column_horizontal_alignment_vector_right_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="237">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="237" />

--- a/tests/test_layout/test_column_horizontal_alignment_vector_stretch_.svg
+++ b/tests/test_layout/test_column_horizontal_alignment_vector_stretch_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="412" height="237">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="412" height="237" />

--- a/tests/test_layout/test_column_vertical_distribution_vector_bottom_.svg
+++ b/tests/test_layout/test_column_vertical_distribution_vector_bottom_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="500">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="500" />

--- a/tests/test_layout/test_column_vertical_distribution_vector_center_.svg
+++ b/tests/test_layout/test_column_vertical_distribution_vector_center_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="500">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="500" />

--- a/tests/test_layout/test_column_vertical_distribution_vector_space_around_.svg
+++ b/tests/test_layout/test_column_vertical_distribution_vector_space_around_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="500">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="500" />

--- a/tests/test_layout/test_column_vertical_distribution_vector_space_between_.svg
+++ b/tests/test_layout/test_column_vertical_distribution_vector_space_between_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="500">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="500" />

--- a/tests/test_layout/test_column_vertical_distribution_vector_space_evenly_.svg
+++ b/tests/test_layout/test_column_vertical_distribution_vector_space_evenly_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="500">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="500" />

--- a/tests/test_layout/test_column_vertical_distribution_vector_top_.svg
+++ b/tests/test_layout/test_column_vertical_distribution_vector_top_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="500">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="500" />

--- a/tests/test_layout/test_column_with_gap_and_distribution_vector_.svg
+++ b/tests/test_layout/test_column_with_gap_and_distribution_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="600">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="600" />

--- a/tests/test_layout/test_column_with_gap_vector_.svg
+++ b/tests/test_layout/test_column_with_gap_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="422" height="267">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="422" height="267" />

--- a/tests/test_layout/test_row_default_layout_vector_.svg
+++ b/tests/test_layout/test_row_default_layout_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="122" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="122" height="67" />

--- a/tests/test_layout/test_row_horizontal_distribution_vector_center_.svg
+++ b/tests/test_layout/test_row_horizontal_distribution_vector_center_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="600" height="67" />

--- a/tests/test_layout/test_row_horizontal_distribution_vector_left_.svg
+++ b/tests/test_layout/test_row_horizontal_distribution_vector_left_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="600" height="67" />

--- a/tests/test_layout/test_row_horizontal_distribution_vector_right_.svg
+++ b/tests/test_layout/test_row_horizontal_distribution_vector_right_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="600" height="67" />

--- a/tests/test_layout/test_row_horizontal_distribution_vector_space_around_.svg
+++ b/tests/test_layout/test_row_horizontal_distribution_vector_space_around_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="600" height="67" />

--- a/tests/test_layout/test_row_horizontal_distribution_vector_space_between_.svg
+++ b/tests/test_layout/test_row_horizontal_distribution_vector_space_between_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="600" height="67" />

--- a/tests/test_layout/test_row_horizontal_distribution_vector_space_evenly_.svg
+++ b/tests/test_layout/test_row_horizontal_distribution_vector_space_evenly_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="600" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="600" height="67" />

--- a/tests/test_layout/test_row_vertical_alignment_vector_bottom_.svg
+++ b/tests/test_layout/test_row_vertical_alignment_vector_bottom_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="122" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="122" height="150" />

--- a/tests/test_layout/test_row_vertical_alignment_vector_center_.svg
+++ b/tests/test_layout/test_row_vertical_alignment_vector_center_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="122" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="122" height="150" />

--- a/tests/test_layout/test_row_vertical_alignment_vector_stretch_.svg
+++ b/tests/test_layout/test_row_vertical_alignment_vector_stretch_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="122" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="122" height="150" />

--- a/tests/test_layout/test_row_vertical_alignment_vector_top_.svg
+++ b/tests/test_layout/test_row_vertical_alignment_vector_top_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="122" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="122" height="150" />

--- a/tests/test_layout/test_row_with_gap_and_distribution_vector_.svg
+++ b/tests/test_layout/test_row_with_gap_and_distribution_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="800" height="67" />

--- a/tests/test_layout/test_row_with_gap_vector_.svg
+++ b/tests/test_layout/test_row_with_gap_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="162" height="67">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="162" height="67" />

--- a/tests/test_outline/test_outline_without_fill_vector_.svg
+++ b/tests/test_outline/test_outline_without_fill_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="490" height="144">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="490" height="144" />

--- a/tests/test_outline/test_render_with_basic_outline_vector_.svg
+++ b/tests/test_outline/test_render_with_basic_outline_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="315" height="144">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="315" height="144" />

--- a/tests/test_outline/test_render_with_gradient_outline_vector_.svg
+++ b/tests/test_outline/test_render_with_gradient_outline_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="560" height="144">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="560" height="144" />

--- a/tests/test_positioning/test_container_with_position_vector_.svg
+++ b/tests/test_positioning/test_container_with_position_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="100" height="100" />

--- a/tests/test_positioning/test_position_absolute_is_removed_from_column_flow_vector_.svg
+++ b/tests/test_positioning/test_position_absolute_is_removed_from_column_flow_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="300">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="200" height="300" />

--- a/tests/test_positioning/test_position_absolute_is_removed_from_row_flow_vector_.svg
+++ b/tests/test_positioning/test_position_absolute_is_removed_from_row_flow_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="400" height="150" />

--- a/tests/test_positioning/test_position_anchors_and_offsets_vector_.svg
+++ b/tests/test_positioning/test_position_anchors_and_offsets_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="300" height="200" />

--- a/tests/test_positioning/test_position_with_mixed_anchors_vector_.svg
+++ b/tests/test_positioning/test_position_with_mixed_anchors_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="200">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="500" height="200" />

--- a/tests/test_positioning/test_position_with_percentages_vector_.svg
+++ b/tests/test_positioning/test_position_with_percentages_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="400" height="300" />

--- a/tests/test_shadows/test_hard_shadow_without_blur_vector_.svg
+++ b/tests/test_shadows/test_hard_shadow_without_blur_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="460" height="178">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="460" height="178" />

--- a/tests/test_shadows/test_render_with_multiple_box_shadows_vector_.svg
+++ b/tests/test_shadows/test_render_with_multiple_box_shadows_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="532" height="172">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="532" height="172" />

--- a/tests/test_shadows/test_render_with_multiple_text_shadows_vector_.svg
+++ b/tests/test_shadows/test_render_with_multiple_text_shadows_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="393" height="178">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="393" height="178" />

--- a/tests/test_shadows/test_render_with_simple_box_shadow_vector_.svg
+++ b/tests/test_shadows/test_render_with_simple_box_shadow_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="511" height="152">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="511" height="152" />

--- a/tests/test_shadows/test_render_with_simple_text_shadow_vector_.svg
+++ b/tests/test_shadows/test_render_with_simple_text_shadow_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="741" height="178">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="741" height="178" />

--- a/tests/test_shadows/test_text_and_box_shadows_together_vector_.svg
+++ b/tests/test_shadows/test_text_and_box_shadows_together_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="537" height="195">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="537" height="195" />

--- a/tests/test_sizing/test_size_absolute_vector_.svg
+++ b/tests/test_sizing/test_size_absolute_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="400" height="150" />

--- a/tests/test_sizing/test_size_fill_available_multiple_children_vector_.svg
+++ b/tests/test_sizing/test_size_fill_available_multiple_children_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="357" height="409">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="357" height="409" />

--- a/tests/test_sizing/test_size_fill_available_single_child_vector_.svg
+++ b/tests/test_sizing/test_size_fill_available_single_child_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ns1="http://www.w3.org/1999/xlink" width="665" height="266">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="665" height="266" />

--- a/tests/test_sizing/test_size_fit_background_image_vector_.svg
+++ b/tests/test_sizing/test_size_fit_background_image_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:ns1="http://www.w3.org/1999/xlink" width="857" height="256">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="857" height="256" />

--- a/tests/test_sizing/test_size_fit_content_on_row_vector_.svg
+++ b/tests/test_sizing/test_size_fit_content_on_row_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="355" height="79">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="355" height="79" />

--- a/tests/test_sizing/test_size_fit_content_on_text_vector_.svg
+++ b/tests/test_sizing/test_size_fit_content_on_text_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="79">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="300" height="79" />

--- a/tests/test_sizing/test_size_percent_height_vector_.svg
+++ b/tests/test_sizing/test_size_percent_height_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="400">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="300" height="400" />

--- a/tests/test_sizing/test_size_percent_width_and_fixed_height_vector_.svg
+++ b/tests/test_sizing/test_size_percent_width_and_fixed_height_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="400" height="200" />

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -11,7 +11,7 @@ def test_svg_with_embedded_font():
     vector_image = canvas.render_as_svg("Embed Test", embed_font=True)
     svg_content = vector_image.svg
 
-    assert "<builders" in svg_content
+    assert "<style" in svg_content
     assert "@font-face" in svg_content
     assert "font-family: 'pictex-Lato'" in svg_content
     assert "src: url('data:font/ttf;base64," in svg_content
@@ -26,7 +26,7 @@ def test_svg_without_embedded_font():
     vector_image = canvas.render_as_svg("No Embed Test", embed_font=False)
     svg_content = vector_image.svg
 
-    assert "<builders" in svg_content
+    assert "<style" in svg_content
     assert "@font-face" in svg_content
     assert "base64" not in svg_content
     assert "font-family: 'pictex-Lato'" in svg_content

--- a/tests/test_text_wrap/test_text_wrap_different_widths_vector_150_.svg
+++ b/tests/test_text_wrap/test_text_wrap_different_widths_vector_150_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="150" height="165">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="150" height="165" />

--- a/tests/test_text_wrap/test_text_wrap_different_widths_vector_250_.svg
+++ b/tests/test_text_wrap/test_text_wrap_different_widths_vector_250_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="250" height="109">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="250" height="109" />

--- a/tests/test_text_wrap/test_text_wrap_different_widths_vector_350_.svg
+++ b/tests/test_text_wrap/test_text_wrap_different_widths_vector_350_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="350" height="95">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="350" height="95" />

--- a/tests/test_text_wrap/test_text_wrap_inherited_from_parent_vector_.svg
+++ b/tests/test_text_wrap/test_text_wrap_inherited_from_parent_vector_.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="520" height="117">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
@@ -32,7 +32,7 @@
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="520" height="117" />

--- a/tests/test_text_wrap/test_text_wrap_nested_containers_vector_.svg
+++ b/tests/test_text_wrap/test_text_wrap_nested_containers_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="107">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="400" height="107" />

--- a/tests/test_text_wrap/test_text_wrap_normal_vs_nowrap_vector_.svg
+++ b/tests/test_text_wrap/test_text_wrap_normal_vs_nowrap_vector_.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1116" height="107">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
@@ -12,7 +12,7 @@
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="1116" height="107" />

--- a/tests/test_text_wrap/test_text_wrap_override_inheritance_vector_.svg
+++ b/tests/test_text_wrap/test_text_wrap_override_inheritance_vector_.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="468" height="150">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
@@ -22,7 +22,7 @@
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="468" height="150" />

--- a/tests/test_text_wrap/test_text_wrap_with_multiline_text_vector_.svg
+++ b/tests/test_text_wrap/test_text_wrap_with_multiline_text_vector_.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="529" height="95">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
@@ -12,7 +12,7 @@
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="529" height="95" />

--- a/tests/test_text_wrap/test_text_wrap_with_percentage_width_vector_.svg
+++ b/tests/test_text_wrap/test_text_wrap_with_percentage_width_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="144">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="300" height="144" />

--- a/tests/test_text_wrap/test_text_wrap_with_styling_vector_.svg
+++ b/tests/test_text_wrap/test_text_wrap_with_styling_vector_.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="280" height="141">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
 @font-face {
     font-family: 'pictex-Lato';
     src: url('/home/runner/work/pictex/pictex/tests/assets/Lato-BoldItalic.ttf');
 }
             
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="280" height="141" />

--- a/tests/test_text_wrap/test_two_sibling_texts_using_width_limited_by_ancestor_vector_.svg
+++ b/tests/test_text_wrap/test_two_sibling_texts_using_width_limited_by_ancestor_vector_.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="780" height="885">
 <defs>
-    <builders type="text/css">
+    <style type="text/css">
         
-    </builders>
+    </style>
 </defs>
             
 	<rect fill-opacity="0" width="780" height="885" />


### PR DESCRIPTION
The resulting SVG file was including the embedded font inside an unknown `<builders>` tag. It was probably a bug introduced in the refactor to the version 1.0, were all the test golden files were regenerated.