### PR TITLE
Fix: Remove deprecated mode parameter from PillowImage.fromarray()

### DIFF
--- a/src/pictex/bitmap_image.py
+++ b/src/pictex/bitmap_image.py
@@ -155,7 +155,7 @@ class BitmapImage:
             )
 
         rgba_array = self.to_numpy('RGBA')
-        return PillowImage.fromarray(rgba_array, mode='RGBA')
+        return PillowImage.fromarray(rgba_array)
 
     def save(self, output_path: str, quality: int = 100) -> None:
         """Saves the image to a file.


### PR DESCRIPTION
## Summary
This PR fixes the deprecation warning from Pillow by removing the `mode` parameter from `PillowImage.fromarray()`.

## Changes
- Removed `mode='RGBA'` parameter from `PillowImage.fromarray()` call in `BitmapImage.to_pillow()`
- The mode is now automatically inferred from the array shape and dtype

## Related Issue
Fixes #15

## Testing
- The change is backward compatible as Pillow automatically detects the mode from RGBA arrays
- No functional changes expected

## Deprecation Warning Fixed
```
DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)
```

---
🤖 This is my first contribution to this project! Please let me know if any changes are needed.